### PR TITLE
Configurable output loggers, Logentries JSON output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
 Metrics/ClassLength:
   Max: 500
 
+Metrics/LineLength:
+  Max: 100
+
 HttpPositionalArguments:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,8 @@ are:
     * `:stdout` to write to STDOUT undecorated (`generated_at` and `level` will be included in the JSON)
     * an IO object that responds to `<<`
     * a logging object that responds to severity methods, e.g. `info`
+
+## Environment variables
+
+* `EVENT_LOGGER_LOGGER` - change the default value of the `logger`
+  configuration option, either `logger` or `stdout`

--- a/README.md
+++ b/README.md
@@ -89,3 +89,23 @@ Then log with the `log` method e.g.:
 	EventLogger.log(:process, name: 'ingest_material', state: 'failed', details: 'cannot upload directory', severity: 'error')
 ## Completed:
 	EventLogger.log(:process, name: 'ingest_material', state: 'completed', clock_number: clock_number, details: 'completed ingest with sidecar from s3')
+
+## Configuration
+
+By default, EventLogger will write to stdout with full Logger headers:
+
+    I, [2017-06-22T09:04:44.827889 #7]  INFO -- : {"type":"process","name":"transcend","state":"start","details":"Starting Transcend Server."}
+
+When using this with the Docker Logentries container, you should instead
+configure the message to be output in JSON format without Logger headers:
+
+    EventLogger.instance.config.logger = :stdout
+
+All available configuration options set via `EventLogger.instance.config`
+are:
+
+* `logger` - set to one of:
+    * `:logger` (default) for `Logger` on STDOUT
+    * `:stdout` to write to STDOUT undecorated (`generated_at` and `level` will be included in the JSON)
+    * an IO object that responds to `<<`
+    * a logging object that responds to severity methods, e.g. `info`

--- a/lib/event_logger/config.rb
+++ b/lib/event_logger/config.rb
@@ -8,7 +8,7 @@ class EventLogger
     attr_reader :logger
 
     def initialize
-      @logger = :logger
+      self.logger = ENV.fetch('EVENT_LOGGER_LOGGER', :logger).to_sym
     end
 
     def logger=(value)

--- a/lib/event_logger/config.rb
+++ b/lib/event_logger/config.rb
@@ -1,0 +1,34 @@
+require 'logger'
+
+require 'event_logger/output/io'
+require 'event_logger/output/logger'
+
+class EventLogger
+  class Config
+    attr_reader :logger
+
+    def initialize
+      @logger = :logger
+    end
+
+    def logger=(value)
+      if value.is_a?(Symbol) && !%i[logger stdout].include?(value)
+        raise ArgumentError, "Unknown logger type: #{value}"
+      end
+
+      @logger = value
+    end
+
+    def logger_instance
+      if logger == :logger
+        EventLogger::Output::Logger.new(Logger.new(STDOUT))
+      elsif logger == :stdout
+        EventLogger::Output::IO.new($stdout)
+      elsif logger.respond_to?(:<<)
+        EventLogger::Output::IO.new(logger)
+      else
+        EventLogger::Output::Logger.new(logger)
+      end
+    end
+  end
+end

--- a/lib/event_logger/output/io.rb
+++ b/lib/event_logger/output/io.rb
@@ -1,0 +1,23 @@
+require 'json'
+
+# Outputs log entries to an IO stream, one JSON hash per entry.
+#
+# Adds `generated_at` and `severity` fields to the hash with the current
+# timestamp in milliseconds and the entry severity.
+class EventLogger
+  module Output
+    class IO
+      attr_reader :stream
+
+      def initialize(stream)
+        @stream = stream
+      end
+
+      def write(severity, details = {})
+        timestamp = (Time.now.to_f * 1000).to_i
+        line = JSON.generate({ generated_at: timestamp, severity: severity }.merge(details))
+        @stream << "#{line}\n"
+      end
+    end
+  end
+end

--- a/lib/event_logger/output/logger.rb
+++ b/lib/event_logger/output/logger.rb
@@ -1,0 +1,21 @@
+require 'json'
+
+# Outputs log entries to a Logger object, one JSON hash per entry.
+#
+# Can be used with the Ruby Logger or another that responds to per-severity
+# methods.
+class EventLogger
+  module Output
+    class Logger
+      attr_reader :logger
+
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def write(severity, details = {})
+        @logger.public_send(severity, JSON.generate(details))
+      end
+    end
+  end
+end

--- a/spec/lib/event_logger/config_spec.rb
+++ b/spec/lib/event_logger/config_spec.rb
@@ -7,6 +7,17 @@ describe EventLogger::Config do
     it 'defaults to :logger' do
       expect(subject.logger).to eq(:logger)
     end
+
+    context 'with EVENT_LOGGER_LOGGER env' do
+      let(:env_logger) { 'stdout' }
+
+      before { ENV['EVENT_LOGGER_LOGGER'] = env_logger }
+      after { ENV.delete('EVENT_LOGGER_LOGGER') }
+
+      it 'defaults to EVENT_LOGGER_LOGGER' do
+        expect(subject.logger).to eq(:stdout)
+      end
+    end
   end
 
   describe '#logger=' do

--- a/spec/lib/event_logger/config_spec.rb
+++ b/spec/lib/event_logger/config_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../../lib/event_logger/config'
+
+describe EventLogger::Config do
+  subject { described_class.new }
+
+  describe '#logger' do
+    it 'defaults to :logger' do
+      expect(subject.logger).to eq(:logger)
+    end
+  end
+
+  describe '#logger=' do
+    it 'sets logger to supported type' do
+      subject.logger = :stdout
+      expect(subject.logger).to eq(:stdout)
+    end
+
+    it 'raises an error if set to unknown symbol' do
+      expect { subject.logger = :unknown }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#logger_instance' do
+    it 'returns Logger for :logger' do
+      subject.logger = :logger
+      expect(subject.logger).to eq(:logger)
+      expect(subject.logger_instance).to be_a(EventLogger::Output::Logger)
+    end
+
+    it 'returns IO(STDOUT) for :stdout' do
+      subject.logger = :stdout
+      expect(subject.logger).to eq(:stdout)
+      expect(subject.logger_instance).to be_a(EventLogger::Output::IO)
+      expect(subject.logger_instance.stream).to eq($stdout)
+    end
+
+    context 'logger object' do
+      let(:output) { instance_double(Object) }
+
+      before { allow(output).to receive(:respond_to?).with(:<<).and_return(false).twice }
+
+      it 'will use the Logger method' do
+        subject.logger = output
+        expect(subject.logger).to eq(output)
+        expect(subject.logger_instance).to be_a(EventLogger::Output::Logger)
+        expect(subject.logger_instance.logger).to eq(output)
+      end
+    end
+
+    context 'IO object' do
+      let(:output) { instance_double(IO) }
+
+      before { allow(output).to receive(:respond_to?).with(:<<).and_return(true).twice }
+
+      it 'will use the IO method' do
+        subject.logger = output
+        expect(subject.logger).to eq(output)
+        expect(subject.logger_instance).to be_a(EventLogger::Output::IO)
+        expect(subject.logger_instance.stream).to eq(output)
+      end
+    end
+  end
+end

--- a/spec/lib/event_logger/output/io_spec.rb
+++ b/spec/lib/event_logger/output/io_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../../lib/event_logger/output/io'
+
+describe EventLogger::Output::IO do
+  subject { described_class.new(buffer) }
+
+  let(:buffer) { StringIO.new }
+
+  describe '#write' do
+    it 'outputs JSON with severity and generated_at' do
+      allow(Time).to receive(:now).and_return(Time.new(2017))
+      subject.write(:warn, type: :process, foo: 'bar')
+      expect(buffer.string)
+        .to eq(%({"generated_at":1483228800000,"severity":"warn","type":"process","foo":"bar"}\n))
+    end
+  end
+end

--- a/spec/lib/event_logger/output/logger_spec.rb
+++ b/spec/lib/event_logger/output/logger_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../../lib/event_logger/output/logger'
+
+describe EventLogger::Output::Logger do
+  subject { described_class.new(Logger.new(STDOUT)) }
+
+  describe '#write' do
+    it 'calls severity method with JSON' do
+      allow(subject.logger).to receive(:warn)
+      subject.write(:warn, type: :process, foo: 'bar')
+      expect(subject.logger).to have_received(:warn).with('{"type":"process","foo":"bar"}')
+    end
+  end
+end

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -6,56 +6,38 @@ require_relative '../../lib/event_logger.rb'
 describe EventLogger do
   subject { described_class.instance }
 
+  let(:output) { instance_double(EventLogger::Output::IO) }
+
+  before { allow(subject.config).to receive(:logger_instance).and_return(output) }
+
   it 'is a singleton' do
     expect(subject).to eq(described_class.instance)
   end
 
-  it 'formats all passed details into JSON' do
-    entry = subject.send :format_log_entry, type: :job,
-                                            name: 'transcoding_job',
-                                            state: :enqueued,
-                                            materialid: 'TTB/GODD004/030'
-
-    expect(entry)
-      .to eq('{"type":"job","name":"transcoding_job",'\
-             '"state":"enqueued","materialid":"TTB/GODD004/030"}')
-  end
-
-  it 'passes the log entry to the logger so it ends up in the right place' do
-    my_logger = instance_spy(Logger)
-    allow(my_logger).to receive(:info)
-    subject.logger = my_logger
-
+  it 'outputs the log entry' do
+    allow(output).to receive(:write)
     subject.log(:job, name: 'make_thumbnails', state: 'failed')
-
-    expect(my_logger)
-      .to have_received(:info)
-      .with('{"type":"job","name":"make_thumbnails","state":"failed"}').once
+    expect(output)
+      .to have_received(:write)
+      .with(:info, type: :job, name: 'make_thumbnails', state: 'failed').once
   end
 
   it 'determines the severity from the event mapping' do
-    my_logger = instance_spy(Logger)
-    allow(my_logger).to receive(:error)
-    subject.logger = my_logger
+    allow(output).to receive(:write)
     subject.mapping = { 'validate' => { state: :failed,
                                         severity: :error } }
     subject.log(:job, name: 'validate', state: :failed)
-
-    expect(my_logger)
-      .to have_received(:error)
-      .with('{"type":"job","name":"validate","state":"failed"}').once
+    expect(output)
+      .to have_received(:write)
+      .with(:error, type: :job, name: 'validate', state: :failed).once
   end
 
   it 'allows overriding of severity' do
-    my_logger = instance_spy(Logger)
-    allow(my_logger).to receive(:warn)
-    subject.logger = my_logger
-
+    allow(output).to receive(:write)
     subject.log(:mark, name: 'all_jobs_scheduled', severity: :warn)
-
-    expect(my_logger)
-      .to have_received(:warn)
-      .with('{"type":"mark","name":"all_jobs_scheduled"}').once
+    expect(output)
+      .to have_received(:write)
+      .with(:warn, type: :mark, name: 'all_jobs_scheduled').once
   end
 
   it 'can create a Correlation ID' do


### PR DESCRIPTION
Logging output can now be sent to STDOUT without Logger, which is useful
with the Docker Logentries container as it expects JSON output without
any Logger headers. This includes severity and a timestamp in the JSON.

For non-Docker use, the Logger time and severity human-readable
formatting is a useful default.

---

Plus allows setting `EVENT_LOGGER_LOGGER=stdout` for easy configuration at deployment-time for Docker Logentries-compatible output.