### PR TITLE
Ensure .log always returns nil

### DIFF
--- a/lib/event_logger.rb
+++ b/lib/event_logger.rb
@@ -30,6 +30,8 @@ class EventLogger
                end.to_sym
 
     config.logger_instance.write severity, details_for(type, details)
+
+    nil
   end
 
   def create_correlation_id

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -22,6 +22,11 @@ describe EventLogger do
       .with(:info, type: :job, name: 'make_thumbnails', state: 'failed').once
   end
 
+  it 'returns nil' do
+    allow(output).to receive(:write).and_return(:io_return_value)
+    expect(subject.log(:job, name: 'make_thumbnails', state: 'failed')).to be_nil
+  end
+
   it 'determines the severity from the event mapping' do
     allow(output).to receive(:write)
     subject.mapping = { 'validate' => { state: :failed,


### PR DESCRIPTION
Prevent IO objects or other return values leaking from of the internal
log instances to the caller.